### PR TITLE
Add actions scanning and community pack in codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,39 @@
+name: CodeQL SAST
+on:
+  push:
+    branches:
+      - feature/packaging
+  pull_request:
+  schedule:
+    - cron: "23 9 * * 3"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["csharp", "actions"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a #v2.20.3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+          packs: githubsecuritylab/codeql-csharp-queries
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a #v2.20.3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a #v2.20.3


### PR DESCRIPTION
## Changes:
- Added [GitHub Actions scanning](https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/)
- Added [codeql-community-packs](https://github.blog/security/vulnerability-research/announcing-codeql-community-packs/)
- Pinned versions updated
